### PR TITLE
Add assertions in switch cases and Task creation

### DIFF
--- a/src/main/java/bmo/javafx/DialogBox.java
+++ b/src/main/java/bmo/javafx/DialogBox.java
@@ -59,7 +59,8 @@ public class DialogBox extends HBox {
         case TODO, DEADLINE, EVENT -> dialog.getStyleClass().add("add-label");
         case MARK, UNMARK, FIND -> dialog.getStyleClass().add("marked-label");
         case DELETE, UNKNOWN -> dialog.getStyleClass().add("delete-label");
-        default -> dialog.getStyleClass().add("response-label");
+        case LIST, BYE -> dialog.getStyleClass().add("response-label");
+        default -> throw new AssertionError(commandWord);
         }
     }
 

--- a/src/main/java/bmo/parser/TaskListParser.java
+++ b/src/main/java/bmo/parser/TaskListParser.java
@@ -94,6 +94,7 @@ public class TaskListParser {
         // Command name does not match any other command
         // Provide command name to parser for reference
         case UNKNOWN -> new UnknownCommandParser(commandName);
+        default -> throw new AssertionError(commandName);
         };
 
         // Parse the parameterText to return a Command

--- a/src/main/java/bmo/task/Deadline.java
+++ b/src/main/java/bmo/task/Deadline.java
@@ -22,6 +22,9 @@ public class Deadline extends Task {
      */
     public Deadline(String description, LocalDateTime due) {
         super(description);
+
+        assert due != null : "Due datetime cannot be null";
+
         this.due = due;
     }
 

--- a/src/main/java/bmo/task/Event.java
+++ b/src/main/java/bmo/task/Event.java
@@ -25,6 +25,10 @@ public class Event extends Task {
      */
     public Event(String description, LocalDateTime start, LocalDateTime end) {
         super(description);
+
+        assert start != null : "Start datetime cannot be null";
+        assert end != null : "End datetime cannot be null";
+
         this.start = start;
         this.end = end;
     }

--- a/src/main/java/bmo/task/Task.java
+++ b/src/main/java/bmo/task/Task.java
@@ -17,6 +17,9 @@ public class Task {
      * @param description The String containing a description of the task
      */
     public Task(String description) {
+        assert description != null : "Description cannot be null";
+        assert !description.trim().isEmpty() : "Description cannot be empty";
+
         this.description = description;
         this.isDone = false;
     }

--- a/src/main/java/bmo/task/TaskList.java
+++ b/src/main/java/bmo/task/TaskList.java
@@ -63,6 +63,8 @@ public class TaskList {
      * @return A task corresponding to the index given, marked as done.
      */
     public Task markTask(int index) {
+        assert index >= 1 && index <= this.getTotal() : "Task index out of range";
+
         Task markTask = this.tasks.get(index - 1);
         markTask.markAsDone();
         return markTask;
@@ -76,6 +78,8 @@ public class TaskList {
      * @return A task corresponding to the index given, marked as not done.
      */
     public Task unmarkTask(int index) {
+        assert index >= 1 && index <= this.getTotal() : "Task index out of range";
+
         Task unmarkTask = this.tasks.get(index - 1);
         unmarkTask.markAsNotDone();
         return unmarkTask;
@@ -89,6 +93,8 @@ public class TaskList {
      * @return A task corresponding to the index given.
      */
     public Task deleteTask(int index) {
+        assert index >= 1 && index <= this.getTotal() : "Task index out of range";
+
         Task deleteTask = this.tasks.get(index - 1);
         this.tasks.remove(index - 1);
         return deleteTask;


### PR DESCRIPTION
There are two places where switch cases are used. They currently have default cases. Additionally, tasks are created simply with the given arguments, since error handling has been done beforehand. Moreover, index-based commands such as mark, unmark and delete run through TaskList, which simply takes in the index.

Adding assertions to these methods will ensure that future changes to the codebase will not result in runtime errors.

Let's,
* add assertions to the switch cases, to ensure all cases have been covered
* add assertions to Task and subclass constructors to avoid invalid objects being created
* add assertions to TaskList methods to avoid causing runtime errors from retrieving tasks from an invalid index